### PR TITLE
Adding option to log consumed and published messages

### DIFF
--- a/.github/workflows/scala.dhall
+++ b/.github/workflows/scala.dhall
@@ -36,7 +36,7 @@ in  GithubActions.Workflow::{
           , name = "Build"
           , needs = None (List Text)
           , strategy = Some GithubActions.Strategy::{ matrix = matrix }
-          , runs-on = GithubActions.types.RunsOn.ubuntu-latest
+          , runs-on = GithubActions.types.RunsOn.`ubuntu-18.04`
           , steps =
                 setup
               # [ GithubActions.steps.java-setup

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,7 +1,7 @@
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: "actions/checkout@v2.1.0"
       - run: |


### PR DESCRIPTION
Synchronizing our changes in the application. I went for plain functions and new constructors because we need to customize how we log out the messages, let me know what you think.

What we currently have in `app` can be translated as:

```scala
val logAction: Array[Byte] => IO[Unit] =
  event => Logger[IO].info( s"[Outgoing Event] ${PrettyLog.truncate(event, "sdp")} at Topic: ${topic.url}")

Publisher.withLogger[IO, Event](client, topic, batching, blocker, logAction)
```

And a very similar story for the `Consumer`:

```scala
val logAction: Array[Byte] => TopicName => IO[Unit] =
  event => topic => Logger[IO].info(s"[Incoming Event] ${PrettyLog.truncate(event, "sdp")} at Topic: $topic"

for {
  consumer <- Consumer.create[IO](client, topic, subscription, subscriptions)
  events = consumer.subscribe.through(
             Consumer.loggingMessageDecoder[IO, Event](consumer, logAction)
           )
  ...
} yield ()
```

We could probably unify both `logAction`s as well. At the moment we have access to the `Topic` in the `Publisher` but not in the `messageDecoder` so their type signature differ.