### PR TITLE
Add publish_ and publishAsync_ + Scala docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A *pulsar* is a celestial object, thought to be a rapidly rotating neutron star,
 
 DISCLAIMER: It is currently a WIP so **there is no release and we do not recommend its wide usage yet**. However, if you would like to give it a try you can find the latest snapshots published here: [https://oss.sonatype.org/#nexus-search;quick~com.chatroulette](https://oss.sonatype.org/#nexus-search;quick~com.chatroulette).
 
-Sooner rather than later we plan to make a first official release and write documentation so it can also be useful outside of our company.Stay tuned!
+Sooner rather than later we plan to make a first official release and write documentation so it can also be useful outside of our company. Stay tuned!
 
 ### Build
 

--- a/src/main/scala/cr/pulsar/Client.scala
+++ b/src/main/scala/cr/pulsar/Client.scala
@@ -8,6 +8,12 @@ object PulsarClient {
 
   type T = Underlying
 
+  /**
+    * It creates an underlying PulsarClient as a [[cats.effect.Resource]]
+    *
+    * It will be closed once the client is no longer in use or in case of
+    * shutdown of the application that makes use of it.
+    */
   def create[F[_]: Sync](url: PulsarURL): Resource[F, T] =
     Resource.fromAutoCloseable(
       F.delay(Underlying.builder.serviceUrl(url.value).build)

--- a/src/main/scala/cr/pulsar/Config.scala
+++ b/src/main/scala/cr/pulsar/Config.scala
@@ -3,6 +3,10 @@ package cr.pulsar
 import Config._
 import io.estatico.newtype.macros._
 
+/**
+  * Basic Pulsar configuration to establish
+  * a connection.
+  */
 case class Config(
     tenant: PulsarTenant,
     namespace: PulsarNamespace,

--- a/src/main/scala/cr/pulsar/Consumer.scala
+++ b/src/main/scala/cr/pulsar/Consumer.scala
@@ -14,6 +14,13 @@ trait Consumer[F[_]] {
 }
 
 object Consumer {
+
+  /**
+    * It creates a simple [[Consumer]].
+    *
+    * Note that this does not create a subscription to any Topic,
+    * you can use [[Consumer#subscribe]] for this purpose.
+    */
   def create[F[_]: Concurrent: ContextShift](
       client: PulsarClient.T,
       topic: Topic,
@@ -47,6 +54,12 @@ object Consumer {
         }
       }
 
+  /**
+    * A simple message decoder that uses a [[cats.Inject]] instance
+    * to deserialise consumed messages.
+    *
+    * Consumed messages will be logged using the given `logAction`.
+    */
   def loggingMessageDecoder[
       F[_]: MonadError[*[_], Throwable]: Parallel,
       E: Inject[*, Array[Byte]]
@@ -68,6 +81,12 @@ object Consumer {
       logAction(data)(Topic.Name(m.getTopicName)) &> acking
     }
 
+  /**
+    * A simple message decoder that uses a [[cats.Inject]] instance
+    * to deserialise consumed messages.
+    *
+    * Messages will not be logged by default.
+    */
   def messageDecoder[
       F[_]: MonadError[*[_], Throwable]: Parallel,
       E: Inject[*, Array[Byte]]

--- a/src/main/scala/cr/pulsar/Subscription.scala
+++ b/src/main/scala/cr/pulsar/Subscription.scala
@@ -4,6 +4,16 @@ import org.apache.pulsar.client.api.SubscriptionType
 
 sealed abstract case class Subscription(name: String, sType: SubscriptionType)
 
+/**
+  * A [[Subscription]] can be one of the following types:
+  *
+  * - [[Subscription.Type.Exclusive]]
+  * - [[Subscription.Type.Failover]]
+  * - [[Subscription.Type.KeyShared]]
+  * - [[Subscription.Type.Shared]]
+  *
+  * Find out more at [[https://pulsar.apache.org/docs/en/concepts-messaging/#subscriptions]]
+  */
 object Subscription {
 
   sealed trait Type {

--- a/src/main/scala/cr/pulsar/Topic.scala
+++ b/src/main/scala/cr/pulsar/Topic.scala
@@ -5,6 +5,15 @@ import io.estatico.newtype.macros.newtype
 
 sealed abstract case class Topic(name: Topic.Name, url: Topic.URL)
 
+/**
+  * Topic names are URLs that have a well-defined structure:
+  *
+  * {{{
+  * {persistent|non-persistent}://tenant/namespace/topic
+  * }}}
+  *
+  * Find out more at [[https://pulsar.apache.org/docs/en/concepts-messaging/#topics]]
+  */
 object Topic {
   import cats.implicits._
 


### PR DESCRIPTION
- Adding two new methods `publish_` and `publishAsync_` that discard their value.
- Working on basic Scala docs.
- Organizing imports.