### PR TITLE
Unifying logAction type signature in consumer and publisher

### DIFF
--- a/src/main/scala/cr/pulsar/Consumer.scala
+++ b/src/main/scala/cr/pulsar/Consumer.scala
@@ -65,7 +65,7 @@ object Consumer {
       E: Inject[*, Array[Byte]]
   ](
       c: Consumer[F],
-      logAction: Array[Byte] => Topic.Name => F[Unit]
+      logAction: Array[Byte] => Topic.URL => F[Unit]
   ): Pipe[F, Message[Array[Byte]], E] =
     _.evalMap { m =>
       val id   = m.getMessageId
@@ -78,7 +78,7 @@ object Consumer {
           c.nack(id) *> (new IllegalArgumentException("Decoding error")).raiseError[F, E]
       }
 
-      logAction(data)(Topic.Name(m.getTopicName)) &> acking
+      logAction(data)(Topic.URL(m.getTopicName)) &> acking
     }
 
   /**


### PR DESCRIPTION
After the changes introduced in https://github.com/cr-org/neutron/pull/9, the `logAction` functions used in `Consumer` and `Publisher` have been left inconsistent. This PR fixes it.