### PR TITLE
Subscription mode

### DIFF
--- a/core/src/it/scala/cr/pulsar/PulsarSpec.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSpec.scala
@@ -25,7 +25,7 @@ import java.util.UUID
 
 class PulsarSpec extends PulsarSuite {
 
-  val sub   = Subscription(Subscription.Name("test"), Subscription.Type.Failover)
+  val sub   = Subscription(Subscription.Name("test"), Subscription.Type.Failover, Subscription.Mode.Durable)
   val topic = Topic(cfg, Topic.Name("test"), Topic.Type.Persistent)
   val batch = Producer.Batching.Disabled
   val shard = (_: Event) => Producer.MessageKey.Default
@@ -68,7 +68,7 @@ class PulsarSpec extends PulsarSuite {
       "A message with key is published and consumed successfully by the right consumer"
     ) {
       val makeSub =
-        (n: String) => Subscription(Subscription.Name(n), Subscription.Type.KeyShared)
+        (n: String) => Subscription(Subscription.Name(n), Subscription.Type.KeyShared, Subscription.Mode.Durable)
 
       val opts =
         Producer.Options[IO, Event]().withShardKey(_.shardKey).withBatching(batch)

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -17,9 +17,13 @@
 package cr.pulsar
 
 import io.estatico.newtype.macros.newtype
-import org.apache.pulsar.client.api.SubscriptionType
+import org.apache.pulsar.client.api.{ SubscriptionMode, SubscriptionType }
 
-sealed abstract case class Subscription(name: String, sType: SubscriptionType)
+sealed abstract case class Subscription(
+    name: String,
+    sType: SubscriptionType,
+    mode: SubscriptionMode
+)
 
 /**
   * A [[Subscription]] can be one of the following types:
@@ -34,6 +38,19 @@ sealed abstract case class Subscription(name: String, sType: SubscriptionType)
 object Subscription {
 
   @newtype case class Name(value: String)
+
+  sealed trait Mode {
+    def pulsarSubscriptionMode: SubscriptionMode
+  }
+
+  object Mode {
+    case object Durable extends Mode {
+      override def pulsarSubscriptionMode: SubscriptionMode = SubscriptionMode.Durable
+    }
+    case object NonDurable extends Mode {
+      override def pulsarSubscriptionMode: SubscriptionMode = SubscriptionMode.NonDurable
+    }
+  }
 
   sealed trait Type {
     def pulsarSubscriptionType: SubscriptionType
@@ -54,7 +71,11 @@ object Subscription {
     }
   }
 
-  def apply(name: Name, sType: Type) =
-    new Subscription(name.value ++ "-subscription", sType.pulsarSubscriptionType) {}
+  def apply(name: Name, sType: Type, mode: Mode) =
+    new Subscription(
+      name.value ++ "-subscription",
+      sType.pulsarSubscriptionType,
+      mode.pulsarSubscriptionMode
+    ) {}
 
 }

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -26,7 +26,7 @@ object Demo extends IOApp {
 
   val config = Config.default
   val topic  = Topic(config, Topic.Name("my-topic"), Topic.Type.NonPersistent)
-  val subs   = Subscription(Subscription.Name("my-sub"), Subscription.Type.Shared)
+  val subs   = Subscription(Subscription.Name("my-sub"), Subscription.Type.Shared, Subscription.Mode.Durable)
 
   val resources: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
     for {


### PR DESCRIPTION
Unsubscribing can now be performed manually but it's called automatically by default.

When having `Subscription.Mode.NonDurable`, the subscription will be garbage-collected when there are no more consumers, even without calling `unsubscribe`. Though, by default it is `Durable` so that's something we might want to configure, specially when having `Subscription.Type.Shared`.