### PR TITLE
Config data builders

### DIFF
--- a/core/src/it/scala/cr/pulsar/PulsarSpec.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSpec.scala
@@ -25,8 +25,8 @@ import java.util.UUID
 
 class PulsarSpec extends PulsarSuite {
 
-  val sub   = Subscription("test").withType(Subscription.Type.Failover)
-  val topic = Topic("test", cfg)
+  val sub   = Subscription(Subscription.Name("test")).withType(Subscription.Type.Failover)
+  val topic = Topic(Topic.Name("test"), cfg)
   val batch = Producer.Batching.Disabled
   val shard = (_: Event) => Producer.MessageKey.Default
 
@@ -68,7 +68,8 @@ class PulsarSpec extends PulsarSuite {
       "A message with key is published and consumed successfully by the right consumer"
     ) {
       val makeSub =
-        (n: String) => Subscription(n).withType(Subscription.Type.KeyShared)
+        (n: String) =>
+          Subscription(Subscription.Name(n)).withType(Subscription.Type.KeyShared)
 
       val opts =
         Producer.Options[IO, Event]().withShardKey(_.shardKey).withBatching(batch)

--- a/core/src/it/scala/cr/pulsar/PulsarSpec.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSpec.scala
@@ -25,8 +25,8 @@ import java.util.UUID
 
 class PulsarSpec extends PulsarSuite {
 
-  val sub   = Subscription(Subscription.Name("test"), Subscription.Type.Failover, Subscription.Mode.Durable)
-  val topic = Topic(cfg, Topic.Name("test"), Topic.Type.Persistent)
+  val sub   = Subscription("test").withType(Subscription.Type.Failover)
+  val topic = Topic("test", cfg)
   val batch = Producer.Batching.Disabled
   val shard = (_: Event) => Producer.MessageKey.Default
 
@@ -68,7 +68,7 @@ class PulsarSpec extends PulsarSuite {
       "A message with key is published and consumed successfully by the right consumer"
     ) {
       val makeSub =
-        (n: String) => Subscription(Subscription.Name(n), Subscription.Type.KeyShared, Subscription.Mode.Durable)
+        (n: String) => Subscription(n).withType(Subscription.Type.KeyShared)
 
       val opts =
         Producer.Options[IO, Event]().withShardKey(_.shardKey).withBatching(batch)

--- a/core/src/it/scala/cr/pulsar/PulsarSuite.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSuite.scala
@@ -20,7 +20,6 @@ import cats._
 import cats.effect._
 import cats.effect.concurrent.Deferred
 import cats.implicits._
-import cr.pulsar.Config._
 import java.util.UUID
 import munit.FunSuite
 import scala.concurrent.ExecutionContext
@@ -32,8 +31,8 @@ abstract class PulsarSuite extends FunSuite {
   implicit val `⏰` = IO.timer(ExecutionContext.global)
 
   private[this] var client: Pulsar.T = null
-  private[this] var close: IO[Unit]        = null
-  private[this] val latch                  = Deferred[IO, Unit].unsafeRunSync()
+  private[this] var close: IO[Unit]  = null
+  private[this] val latch            = Deferred[IO, Unit].unsafeRunSync()
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms :+ new ValueTransform("IO", {
@@ -81,10 +80,6 @@ abstract class PulsarSuite extends FunSuite {
       }
   }
 
-  lazy val cfg = Config(
-    PulsarTenant("public"),
-    PulsarNamespace("default"),
-    PulsarURL("pulsar://localhost:6650")
-  )
+  lazy val cfg = Config.Default
 
 }

--- a/core/src/main/scala/cr/pulsar/Config.scala
+++ b/core/src/main/scala/cr/pulsar/Config.scala
@@ -23,20 +23,44 @@ import io.estatico.newtype.macros._
   * Basic Pulsar configuration to establish
   * a connection.
   */
-case class Config(
-    tenant: PulsarTenant,
-    namespace: PulsarNamespace,
-    serviceUrl: PulsarURL
-)
+sealed abstract class Config {
+  val tenant: PulsarTenant
+  val namespace: PulsarNamespace
+  val serviceUrl: PulsarURL
+  def withTenant(_tenant: PulsarTenant): Config
+  def withNamespace(_namespace: PulsarNamespace): Config
+  def withURL(_url: PulsarURL): Config
+}
 
 object Config {
   @newtype case class PulsarTenant(value: String)
   @newtype case class PulsarNamespace(value: String)
   @newtype case class PulsarURL(value: String)
 
-  val default: Config = Config(
-    PulsarTenant("public"),
-    PulsarNamespace("default"),
-    PulsarURL("pulsar://localhost:6650")
-  )
+  private case class ConfigImpl(
+      tenant: PulsarTenant,
+      namespace: PulsarNamespace,
+      serviceUrl: PulsarURL
+  ) extends Config {
+    def withTenant(_tenant: PulsarTenant): Config =
+      copy(tenant = _tenant)
+    def withNamespace(_namespace: PulsarNamespace): Config =
+      copy(namespace = _namespace)
+    def withURL(_serviceUrl: PulsarURL): Config =
+      copy(serviceUrl = _serviceUrl)
+  }
+
+  /**
+    * It creates a default configuration.
+    *
+    * - tenant: "public"
+    * - namespace: "default"
+    * - url: "pulsar://localhost:6650"
+    */
+  def Default: Config =
+    ConfigImpl(
+      PulsarTenant("public"),
+      PulsarNamespace("default"),
+      PulsarURL("pulsar://localhost:6650")
+    )
 }

--- a/core/src/main/scala/cr/pulsar/Consumer.scala
+++ b/core/src/main/scala/cr/pulsar/Consumer.scala
@@ -65,9 +65,9 @@ object Consumer {
             p => c.topicsPattern(p.url.value.r.pattern),
             t => c.topic(t.url.value)
           )
-          .subscriptionType(sub.sType)
-          .subscriptionName(sub.name)
-          .subscriptionMode(sub.mode)
+          .subscriptionType(sub.`type`.pulsarSubscriptionType)
+          .subscriptionName(sub.name.value)
+          .subscriptionMode(sub.mode.pulsarSubscriptionMode)
           .subscriptionInitialPosition(opts.initial)
           .subscribeAsync
       }.futureLift

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -90,8 +90,8 @@ object Subscription {
     * - type: Exclusive
     * - mode: Durable
     */
-  def apply(name: String): Subscription =
+  def apply(name: Name): Subscription =
     // Same as Java's defaults: https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java#L62
-    SubscriptionImpl(Name(s"$name-subscription"), Type.Exclusive, Mode.Durable)
+    SubscriptionImpl(Name(s"${name.value}-subscription"), Type.Exclusive, Mode.Durable)
 
 }

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -19,11 +19,14 @@ package cr.pulsar
 import io.estatico.newtype.macros.newtype
 import org.apache.pulsar.client.api.{ SubscriptionMode, SubscriptionType }
 
-sealed abstract case class Subscription(
-    name: String,
-    sType: SubscriptionType,
-    mode: SubscriptionMode
-)
+// Builder-style abstract class instead of case class to allow for bincompat-friendly extension in future versions.
+sealed abstract class Subscription {
+  val name: Subscription.Name
+  val `type`: Subscription.Type
+  val mode: Subscription.Mode
+  def withType(_type: Subscription.Type): Subscription
+  def withMode(_mode: Subscription.Mode): Subscription
+}
 
 /**
   * A [[Subscription]] can be one of the following types:
@@ -36,7 +39,6 @@ sealed abstract case class Subscription(
   * Find out more at [[https://pulsar.apache.org/docs/en/concepts-messaging/#subscriptions]]
   */
 object Subscription {
-
   @newtype case class Name(value: String)
 
   sealed trait Mode {
@@ -71,11 +73,25 @@ object Subscription {
     }
   }
 
-  def apply(name: Name, sType: Type, mode: Mode) =
-    new Subscription(
-      name.value ++ "-subscription",
-      sType.pulsarSubscriptionType,
-      mode.pulsarSubscriptionMode
-    ) {}
+  private case class SubscriptionImpl(
+      name: Subscription.Name,
+      `type`: Subscription.Type,
+      mode: Subscription.Mode
+  ) extends Subscription {
+    def withType(_type: Subscription.Type): Subscription =
+      copy(`type` = _type)
+    def withMode(_mode: Subscription.Mode): Subscription =
+      copy(mode = _mode)
+  }
+
+  /**
+    * It creates a subscription with default configuration.
+    *
+    * - type: Exclusive
+    * - mode: Durable
+    */
+  def apply(name: String): Subscription =
+    // Same as Java's defaults: https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java#L62
+    SubscriptionImpl(Name(s"$name-subscription"), Type.Exclusive, Mode.Durable)
 
 }

--- a/core/src/main/scala/cr/pulsar/Topic.scala
+++ b/core/src/main/scala/cr/pulsar/Topic.scala
@@ -70,10 +70,8 @@ object Topic {
     *
     * - type: Persistent
     */
-  def apply(name: String, cfg: Config): Topic = {
-    val _name = Name(name)
-    TopicImpl(_name, buildUrl(cfg, _name, Type.Persistent), cfg)
-  }
+  def apply(name: Name, cfg: Config): Topic =
+    TopicImpl(name, buildUrl(cfg, name, Type.Persistent), cfg)
 
   // ------- Pattern topic -------
 
@@ -101,9 +99,7 @@ object Topic {
     *
     * - type: Persistent
     */
-  def pattern(regex: Regex, cfg: Config): Topic.Pattern = {
-    val np = NamePattern(regex)
-    PatternImpl(np, buildRegexUrl(cfg, np, Type.Persistent), cfg)
-  }
+  def pattern(namePattern: NamePattern, cfg: Config): Topic.Pattern =
+    PatternImpl(namePattern, buildRegexUrl(cfg, namePattern, Type.Persistent), cfg)
 
 }

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -25,8 +25,8 @@ import scala.concurrent.duration._
 object Demo extends IOApp {
 
   val config = Config.Default
-  val topic  = Topic("my-topic", config).withType(Topic.Type.NonPersistent)
-  val subs   = Subscription("my-sub").withType(Subscription.Type.Shared)
+  val topic  = Topic(Topic.Name("my-topic"), config).withType(Topic.Type.NonPersistent)
+  val subs   = Subscription(Subscription.Name("my-sub")).withType(Subscription.Type.Shared)
 
   val resources: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
     for {

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -24,9 +24,9 @@ import scala.concurrent.duration._
 
 object Demo extends IOApp {
 
-  val config = Config.default
-  val topic  = Topic(config, Topic.Name("my-topic"), Topic.Type.NonPersistent)
-  val subs   = Subscription(Subscription.Name("my-sub"), Subscription.Type.Shared, Subscription.Mode.Durable)
+  val config = Config.Default
+  val topic  = Topic("my-topic", config).withType(Topic.Type.NonPersistent)
+  val subs   = Subscription("my-sub").withType(Subscription.Type.Shared)
 
   val resources: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
     for {


### PR DESCRIPTION
Builders for `Config`, `Topic`, and `Subscription` in the same style of `Consumer.Options`, with the Java lib defaults.

For example: https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java#L62