### PR TITLE
Type-level builders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import Dependencies._
 import Settings._
 
+scalaVersion in ThisBuild := "2.13.2"
+
 lazy val `neutron-core` = (project in file("core"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)

--- a/core/src/it/scala/cr/pulsar/PulsarSuite.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSuite.scala
@@ -41,8 +41,7 @@ abstract class PulsarSuite extends FunSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val (cli, release) =
-      Pulsar.create[IO](cfg.serviceUrl).allocated.unsafeRunSync()
+    val (cli, release) = Pulsar.create[IO](cfg.url).allocated.unsafeRunSync()
     this.client = cli
     this.close = release
     latch.complete(()).unsafeRunSync()
@@ -80,6 +79,6 @@ abstract class PulsarSuite extends FunSuite {
       }
   }
 
-  lazy val cfg = Config.Default
+  lazy val cfg = Config.Builder.default
 
 }

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -24,13 +24,24 @@ import scala.concurrent.duration._
 
 object Demo extends IOApp {
 
-  val config = Config.Default
-  val topic  = Topic(Topic.Name("my-topic"), config).withType(Topic.Type.NonPersistent)
-  val subs   = Subscription(Subscription.Name("my-sub")).withType(Subscription.Type.Shared)
+  val config = Config.Builder.default
+
+  val topic  =
+    Topic.Builder
+      .withName(Topic.Name("my-topic"))
+      .withConfig(config)
+      .withType(Topic.Type.NonPersistent)
+      .build
+
+  val subs =
+    Subscription.Builder
+      .withName(Subscription.Name("my-sub"))
+      .withType(Subscription.Type.Shared)
+      .build
 
   val resources: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
     for {
-      pulsar   <- Pulsar.create[IO](config.serviceUrl)
+      pulsar   <- Pulsar.create[IO](config.url)
       consumer <- Consumer.create[IO, String](pulsar, topic, subs)
       producer <- Producer.create[IO, String](pulsar, topic)
     } yield (consumer, producer)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,7 +11,7 @@ object Settings {
     autoAPIMappings := true,
     testFrameworks += new TestFramework("munit.Framework"),
     libraryDependencies ++= macroParadisePlugin(scalaVersion.value),
-    ThisBuild / crossScalaVersions := Seq("2.12.10", "2.13.2"),
+    ThisBuild / crossScalaVersions := Seq("2.13.2"),
     ThisBuild / homepage := Some(url("https://github.com/cr-org/neutron")),
     ThisBuild / organization := "com.chatroulette",
     ThisBuild / organizationName := "Chatroulette",


### PR DESCRIPTION
This how the `Subscription` builder looks like, for example:

```scala
Subscription.Builder
  .withName(Subscription.Name("test"))
  .withType(Subscription.Type.Failover)
  .build
```

If we do not provide a name, which is mandatory, we get a compile-time error with a friendly message:

```scala
sbt:neutron> it:compile
[info] Compiling 1 Scala source to /home/gvolpe/workspace/cr/neutron/core/target/scala-2.12/it-classes ...
[error] /home/gvolpe/workspace/cr/neutron/core/src/it/scala/cr/pulsar/PulsarSpec.scala:33:8: Subscription.Name is mandatory. By default Type=Exclusive and Mode=Durable.
[error]       .build
[error]        ^
[error] one error found
```

I'm also dropping support for Scala 2.12.x since we soon plan to add support for Dotty instead.

Credits: https://pedrorijo.com/blog/typesafe-builder/