### PR TITLE
Overloaded builder methods

### DIFF
--- a/core/src/it/scala/cr/pulsar/PulsarSpec.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSpec.scala
@@ -28,13 +28,13 @@ class PulsarSpec extends PulsarSuite {
 
   val sub = (s: String) =>
     Subscription.Builder
-      .withName(Subscription.Name(s))
+      .withName(s)
       .withType(Subscription.Type.Failover)
       .build
 
   val topic = (s: String) =>
     Topic.Builder
-      .withName(Topic.Name(s))
+      .withName(s)
       .withConfig(cfg)
       .build
 
@@ -119,7 +119,7 @@ class PulsarSpec extends PulsarSuite {
       val makeSub =
         (n: String) =>
           Subscription.Builder
-            .withName(Subscription.Name(n))
+            .withName(n)
             .withType(Subscription.Type.KeyShared)
             .build
 

--- a/core/src/main/scala/cr/pulsar/Config.scala
+++ b/core/src/main/scala/cr/pulsar/Config.scala
@@ -54,11 +54,20 @@ object Config {
     def withTenant(tenant: PulsarTenant): ConfigBuilder[I with Info.Tenant] =
       this.copy(_tenant = tenant)
 
+    def withTenant(tenant: String): ConfigBuilder[I with Info.Tenant] =
+      withTenant(PulsarTenant(tenant))
+
     def withNameSpace(namespace: PulsarNamespace): ConfigBuilder[I with Info.Namespace] =
       this.copy(_namespace = namespace)
 
+    def withNameSpace(namespace: String): ConfigBuilder[I with Info.Namespace] =
+      withNameSpace(PulsarNamespace(namespace))
+
     def withURL(url: PulsarURL): ConfigBuilder[I with Info.URL] =
       this.copy(_url = url)
+
+    def withURL(url: String): ConfigBuilder[I with Info.URL] =
+      withURL(PulsarURL(url))
 
     /**
       * It creates a new configuration.
@@ -83,9 +92,9 @@ object Config {
       */
     def default: Config =
       Config.Builder
-        .withTenant(PulsarTenant("public"))
-        .withNameSpace(PulsarNamespace("default"))
-        .withURL(PulsarURL("pulsar://localhost:6650"))
+        .withTenant("public")
+        .withNameSpace("default")
+        .withURL("pulsar://localhost:6650")
         .build
 
   }

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -90,6 +90,9 @@ object Subscription {
     def withName(name: Name): SubscriptionBuilder[I with Info.Name] =
       this.copy(_name = Name(s"${name.value}-subscription"))
 
+    def withName(name: String): SubscriptionBuilder[I with Info.Name] =
+      withName(Name(name))
+
     def withMode(mode: Mode): SubscriptionBuilder[I with Info.Mode] =
       this.copy(_mode = mode)
 

--- a/core/src/main/scala/cr/pulsar/Topic.scala
+++ b/core/src/main/scala/cr/pulsar/Topic.scala
@@ -16,7 +16,7 @@
 
 package cr.pulsar
 
-import cats.Show.show
+import cats.Show
 import cats.syntax.all._
 import io.estatico.newtype.macros.newtype
 import scala.annotation.implicitNotFound
@@ -38,6 +38,9 @@ sealed abstract class Topic {
   */
 object Topic {
 
+  implicit val showTopic: Show[Topic] =
+    Show[String].contramap(_.url.value)
+
   @newtype case class Name(value: String)
   @newtype case class NamePattern(value: Regex)
   @newtype case class URL(value: String)
@@ -46,7 +49,7 @@ object Topic {
   object Type {
     case object Persistent extends Type
     case object NonPersistent extends Type
-    implicit val showInstance = show[Type] {
+    implicit val showType = Show.show[Type] {
       case Persistent    => "persistent"
       case NonPersistent => "non-persistent"
     }
@@ -86,8 +89,14 @@ object Topic {
     def withName(name: Name): TopicBuilder[I with Info.Name] =
       this.copy(_name = name)
 
+    def withName(name: String): TopicBuilder[I with Info.Name] =
+      withName(Name(name))
+
     def withNamePattern(pattern: NamePattern): TopicBuilder[I with Info.Pattern] =
       this.copy(_pattern = pattern)
+
+    def withNamePattern(regex: Regex): TopicBuilder[I with Info.Pattern] =
+      withNamePattern(NamePattern(regex))
 
     def withConfig(config: Config): TopicBuilder[I with Info.Config] =
       this.copy(_config = config)

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -28,14 +28,14 @@ object Demo extends IOApp {
 
   val topic  =
     Topic.Builder
-      .withName(Topic.Name("my-topic"))
+      .withName("my-topic")
       .withConfig(config)
       .withType(Topic.Type.NonPersistent)
       .build
 
   val subs =
     Subscription.Builder
-      .withName(Subscription.Name("my-sub"))
+      .withName("my-sub")
       .withType(Subscription.Type.Shared)
       .build
 


### PR DESCRIPTION
When creating a builder type manually, it's redundant to wrap a String in a newtype but they are useful when used together with Ciris, for example. With overloaded methods we can have both for different situations. 