### PR TITLE
Exclusive nix-shell for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "Run with JDK8 🚀"
-        run: nix-shell --argstr java jdk8 --run "sbt ++ 'test;makeSite;it:test'"
+        run: nix-shell --argstr java jdk8 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
 
       - name: "Run with JDK11 🚀"
-        run: nix-shell --argstr java jdk11 --run "sbt ++ 'test;makeSite;it:test'"
+        run: nix-shell --argstr java jdk11 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
 
       - name: "Run with JDK14 🚀"
-        run: nix-shell --argstr java jdk14 --run "sbt ++ 'test;makeSite;it:test'"
+        run: nix-shell --argstr java jdk14 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
 
       - name: "Shutting down Pulsar 🐳"
         run: docker-compose down

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -32,4 +32,4 @@ jobs:
       - run: git config --global user.name "neutron-site-bot"
 
       - name: "Build microsite 🚧"
-        run: "nix-shell --run \"sbt ghpagesPushSite\""
+        run: nix-shell --run "sbt ghpagesPushSite"

--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,8 @@
+{ java ? "jdk11" }:
+
+let
+  pkgs = import ./pkgs.nix { inherit java; };
+in
+  pkgs.mkShell {
+    buildInputs = [ pkgs.sbt ];
+  }


### PR DESCRIPTION
An exclusive Nix shell for the CI build only with the `sbt` package. I'm hoping it will improve CI build times since we don't need `java`, `javac` and `gnupg` in scope for building.