### PR TITLE
Parallel jobs for different JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java:
+          - jdk8
+          - jdk11
+          - jdk14
     steps:
       - uses: actions/checkout@v2.3.2
 
@@ -28,14 +34,8 @@ jobs:
           name: neutron
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
-      - name: "Run with JDK8 🚀"
-        run: nix-shell --argstr java jdk8 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
-
-      - name: "Run with JDK11 🚀"
-        run: nix-shell --argstr java jdk11 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
-
-      - name: "Run with JDK14 🚀"
-        run: nix-shell --argstr java jdk14 --run "sbt ++ 'test;makeSite;it:test'" ci.nix
+      - name: "Run with ${{ matrix.java }} 🚀"
+        run: nix-shell --argstr java "${{ matrix.java }}" --run "sbt ++ 'test;makeSite;it:test'" ci.nix
 
       - name: "Shutting down Pulsar 🐳"
         run: docker-compose down

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,9 @@ pull_request_rules:
   - name: automatically merge Scala Steward PRs on CI success
     conditions:
       - author=scala-steward
-      - status-success=Build
+      - "status-success=Build (jdk8)"
+      - "status-success=Build (jdk11)"
+      - "status-success=Build (jdk14)"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Seeing if this improves the CI build times. Initially, I was running all of the jobs with different JDKs in the same job because of the Pulsar dependency but the times should improve by running them in parallel, even if we have to spin up a Pulsar instance per job.