### PR TITLE
Update nixpkgs

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -2,22 +2,16 @@
 
 let
   nixpkgs = fetchTarball {
-    name   = "NixOS-unstable-13-05-2020";
-    url    = "https://github.com/NixOS/nixpkgs-channels/archive/6bcb1dec8ea.tar.gz";
-    sha256 = "04x750byjr397d3mfwkl09b2cz7z71fcykhvn8ypxrck8w7kdi1h";
+    name   = "nixos-unstable-2020-09-25";
+    url    = "https://github.com/NixOS/nixpkgs-channels/archive/72b9660dc18b.tar.gz";
+    sha256 = "1cqgpw263bz261bgz34j6hiawi4hi6smwp6981yz375fx0g6kmss";
   };
 
   config = {
     packageOverrides = p: {
-      sbt = p.sbt.overrideAttrs (
-        old: rec {
-          version = "1.3.13";
-          sbtJdk  = p.${java};
-          patchPhase = ''
-            echo -java-home ${sbtJdk} >> conf/sbtopts
-          '';
-        }
-      );
+      sbt = p.sbt.override {
+        jre = p.${java};
+      };
     };
   };
 


### PR DESCRIPTION
Also simplify the `sbt.override` since we don't need to override the version (specified at `project/build.properties`).