### PR TITLE
Scala 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "Run with ${{ matrix.java }} 🚀"
-        run: nix-shell --argstr java "${{ matrix.java }}" --run "sbt ++ 'test;makeSite;doc;it:test'" nix/ci.nix
+        run: nix-shell --argstr java "${{ matrix.java }}" --run "sbt ';mdoc;makeSite;doc;+test;+it:test'" nix/ci.nix
 
       - name: "Shutting down Pulsar 🐳"
         run: docker-compose down

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,12 +8,16 @@ danglingParentheses                          = true
 maxColumn                                    = 90
 newlines.afterImplicitKWInVerticalMultiline  = true
 newlines.beforeImplicitKWInVerticalMultiline = true
-project.excludeFilters                       = [ .scalafmt.conf ]
 project.git                                  = true
 rewrite.rules                                = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]
 spaces.inImportCurlyBraces                   = true
 style                                        = defaultWithAlign
 unindentTopLevelOperators                    = true
+
+project.excludeFilters = [
+   ".*scala-3.*",
+   ".scalafmt.conf"
+]
 
 rewriteTokens {
   "⇒" = "=>"

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,34 @@
 import Dependencies._
 import Settings._
 
-scalaVersion in ThisBuild := "2.13.2"
+scalaVersion in ThisBuild := "2.13.4"
+
+def extraDeps(scalaVersion: String): List[ModuleID] =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, _)) =>
+      List(
+        CompilerPlugins.betterMonadicFor,
+        CompilerPlugins.kindProjector,
+        Libraries.newtype
+      )
+    case _ => Nil
+  }
 
 lazy val `neutron-core` = (project in file("core"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
+  .settings(scalacOptions ++= compilerFlags(scalaVersion.value))
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings,
     libraryDependencies ++= List(
-          CompilerPlugins.betterMonadicFor,
-          CompilerPlugins.contextApplied,
-          CompilerPlugins.kindProjector,
           Libraries.cats,
           Libraries.catsEffect,
           Libraries.fs2,
-          Libraries.newtype,
           Libraries.pulsar,
           Libraries.munitCore       % "it,test",
           Libraries.munitScalacheck % "it,test"
-        )
+        ) ++ extraDeps(scalaVersion.value)
   )
 
 lazy val `neutron-circe` = (project in file("circe"))
@@ -40,14 +48,11 @@ lazy val `neutron-function` = (project in file("function"))
   .settings(
     libraryDependencies ++= List(
           Libraries.pulsarFunctionsApi,
-          Libraries.java8Compat,
-          Libraries.newtype,
           Libraries.cats            % Test,
           Libraries.catsEffect      % Test,
           Libraries.munitCore       % Test,
-          Libraries.munitScalacheck % Test,
-          Libraries.cats            % Test
-        )
+          Libraries.munitScalacheck % Test
+        ) ++ extraDeps(scalaVersion.value)
   )
 
 lazy val docs = (project in file("docs"))

--- a/core/src/it/scala/cr/pulsar/PulsarSuite.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSuite.scala
@@ -27,8 +27,8 @@ import scala.util.Try
 
 abstract class PulsarSuite extends FunSuite {
 
-  implicit val `⏳` = IO.contextShift(ExecutionContext.global)
-  implicit val `⏰` = IO.timer(ExecutionContext.global)
+  implicit val `⏳` : ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val `⏰` : Timer[IO]        = IO.timer(ExecutionContext.global)
 
   private[this] var client: Pulsar.T = null
   private[this] var close: IO[Unit]  = null
@@ -36,7 +36,7 @@ abstract class PulsarSuite extends FunSuite {
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms :+ new ValueTransform("IO", {
-          case ioa: IO[_] => IO.suspend(ioa).unsafeToFuture
+          case ioa: IO[_] => IO.suspend(ioa).unsafeToFuture()
         })
 
   override def beforeAll(): Unit = {
@@ -55,7 +55,7 @@ abstract class PulsarSuite extends FunSuite {
   def withPulsarClient(f: (=> Pulsar.T) => Unit): Unit =
     f {
       //to ensure the resource has been allocated before any test(...) call
-      latch.get.unsafeRunSync
+      latch.get.unsafeRunSync()
       client
     }
 

--- a/core/src/main/scala-2.13/cr/pulsar/ConfigBuilderExtra.scala
+++ b/core/src/main/scala-2.13/cr/pulsar/ConfigBuilderExtra.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import cr.pulsar.Config._
+import cr.pulsar.data._
+
+abstract class ConfigBuilderExtra[I <: Info] { self: ConfigBuilder[I] =>
+  def withTenant(tenant: String): ConfigBuilder[I with Info.Tenant] =
+    self.withTenant(PulsarTenant(tenant))
+
+  def withNameSpace(namespace: String): ConfigBuilder[I with Info.Namespace] =
+    self.withNameSpace(PulsarNamespace(namespace))
+
+  def withURL(url: String): ConfigBuilder[I with Info.URL] =
+    self.withURL(PulsarURL(url))
+}

--- a/core/src/main/scala-2.13/cr/pulsar/SubscriptionBuilderExtra.scala
+++ b/core/src/main/scala-2.13/cr/pulsar/SubscriptionBuilderExtra.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import cr.pulsar.Subscription._
+import cr.pulsar.data._
+
+abstract class SubscriptionBuilderExtra[I <: Info] { self: SubscriptionBuilder[I] =>
+  def withName(name: String): SubscriptionBuilder[I with Info.Name] =
+    self.withName(SubscriptionName(name))
+}

--- a/core/src/main/scala-2.13/cr/pulsar/TopicBuilderExtra.scala
+++ b/core/src/main/scala-2.13/cr/pulsar/TopicBuilderExtra.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.util.matching.Regex
+
+import cr.pulsar.Topic._
+import cr.pulsar.data._
+
+abstract class TopicBuilderExtra[I <: Info] { self: TopicBuilder[I] =>
+  def withName(name: String): TopicBuilder[I with Info.Name] =
+    self.withName(TopicName(name))
+
+  def withNamePattern(regex: Regex): TopicBuilder[I with Info.Pattern] =
+    self.withNamePattern(TopicNamePattern(regex))
+}

--- a/core/src/main/scala-2.13/cr/pulsar/data.scala
+++ b/core/src/main/scala-2.13/cr/pulsar/data.scala
@@ -16,22 +16,23 @@
 
 package cr.pulsar
 
-import java.util
+import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
 
-import scala.jdk.CollectionConverters._
+import io.estatico.newtype.macros._
 
-import org.apache.pulsar.functions.api.{
-  Record => JavaRecord,
-  WindowContext => JavaWindowContext,
-  WindowFunction => JavaWindowFunction
-}
+object data {
+  @newtype case class OperationTimeout(value: FiniteDuration)
+  @newtype case class ConnectionTimeout(value: FiniteDuration)
 
-trait WindowFunction[In, Out] extends JavaWindowFunction[In, Out] {
-  def handle(input: Seq[Record[In]], context: WindowContext): Out
+  @newtype case class PulsarTenant(value: String)
+  @newtype case class PulsarNamespace(value: String)
+  @newtype case class PulsarURL(value: String)
 
-  override def process(
-      input: util.Collection[JavaRecord[In]],
-      context: JavaWindowContext
-  ): Out =
-    handle(input.asScala.toSeq.map(Record(_)), WindowContext(context))
+  @newtype case class SubscriptionName(value: String)
+
+  @newtype case class TopicName(value: String)
+  @newtype case class TopicNamePattern(value: Regex)
+  @newtype case class TopicURL(value: String)
+
 }

--- a/core/src/main/scala-3/cr/pulsar/ConfigBuilderExtra.scala
+++ b/core/src/main/scala-3/cr/pulsar/ConfigBuilderExtra.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.annotation.targetName
+
+import cr.pulsar.Config._
+import cr.pulsar.data._
+
+abstract class ConfigBuilderExtra[I <: Info] { self: ConfigBuilder[I] =>
+  @targetName("withTenant_string")
+  def withTenant(tenant: String): ConfigBuilder[I with Info.Tenant] =
+    self.withTenant(PulsarTenant(tenant))
+
+  @targetName("withNamespace_string")
+  def withNameSpace(namespace: String): ConfigBuilder[I with Info.Namespace] =
+    self.withNameSpace(PulsarNamespace(namespace))
+
+  @targetName("withURL_string")
+  def withURL(url: String): ConfigBuilder[I with Info.URL] =
+    self.withURL(PulsarURL(url))
+}
+

--- a/core/src/main/scala-3/cr/pulsar/SubscriptionBuilderExtra.scala
+++ b/core/src/main/scala-3/cr/pulsar/SubscriptionBuilderExtra.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.annotation.targetName
+
+import cr.pulsar.Subscription._
+import cr.pulsar.data._
+
+abstract class SubscriptionBuilderExtra[I <: Info] { self: SubscriptionBuilder[I] =>
+  @targetName("withName_string")
+  def withName(name: String): SubscriptionBuilder[I with Info.Name] =
+    self.withName(SubscriptionName(name))
+}

--- a/core/src/main/scala-3/cr/pulsar/TopicBuilderExtra.scala
+++ b/core/src/main/scala-3/cr/pulsar/TopicBuilderExtra.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.annotation.targetName
+import scala.util.matching.Regex
+
+import cr.pulsar.Topic._
+import cr.pulsar.data._
+
+abstract class TopicBuilderExtra[I <: Info] { self: TopicBuilder[I] =>
+  @targetName("withName_string")
+  def withName(name: String): TopicBuilder[I with Info.Name] =
+    self.withName(TopicName(name))
+
+  @targetName("withNamePattern_regex")
+  def withNamePattern(regex: Regex): TopicBuilder[I with Info.Pattern] =
+    self.withNamePattern(TopicNamePattern(regex))
+}

--- a/core/src/main/scala-3/cr/pulsar/data.scala
+++ b/core/src/main/scala-3/cr/pulsar/data.scala
@@ -16,64 +16,63 @@
 
 package cr.pulsar
 
-import scala.annotation.targetName
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
 
 object data:
   opaque type OperationTimeout = FiniteDuration
-  def OperationTimeout(v: FiniteDuration): OperationTimeout = v
-  extension (x: OperationTimeout)
-    @targetName("value_OperationTimeout")
-    def value: FiniteDuration = x
+  object OperationTimeout {
+    def apply(v: FiniteDuration): OperationTimeout = v
+    extension (x: OperationTimeout) def value: FiniteDuration = x
+  }
 
   opaque type ConnectionTimeout = FiniteDuration
-  def ConnectionTimeout(v: FiniteDuration): ConnectionTimeout = v
-  extension (x: ConnectionTimeout)
-    @targetName("value_ConnectionTimeout")
-    def value: FiniteDuration = x
+  object ConnectionTimeout {
+    def apply(v: FiniteDuration): ConnectionTimeout = v
+    extension (x: ConnectionTimeout) def value: FiniteDuration = x
+  }
 
   opaque type PulsarTenant = String
-  def PulsarTenant(v: String): PulsarTenant = v
-  extension (x: PulsarTenant)
-    @targetName("value_PulsarTenant")
-    def value: String = x
+  object PulsarTenant {
+    def apply(v: String): PulsarTenant = v
+    extension (x: PulsarTenant) def value: String = x
+  }
 
   opaque type PulsarNamespace = String
-  def PulsarNamespace(v: String): PulsarNamespace = v
-  extension (x: PulsarNamespace)
-    @targetName("value_PulsarNamespace")
-    def value: String = x
+  object PulsarNamespace {
+    def apply(v: String): PulsarNamespace = v
+    extension (x: PulsarNamespace) def value: String = x
+  }
 
   opaque type PulsarURL = String
-  def PulsarURL(v: String): PulsarURL = v
-  extension (x: PulsarURL)
-    @targetName("value_PulsarURL")
-    def value: String = x
+  object PulsarURL {
+    def apply(v: String): PulsarURL = v
+    extension (x: PulsarURL) def value: String = x
+  }
 
   opaque type SubscriptionName = String
-  def SubscriptionName(v: String): SubscriptionName = v
-  extension (x: SubscriptionName)
-    @targetName("value_SubscriptionName")
-    def value: String = x
+  object SubscriptionName {
+    def apply(v: String): SubscriptionName = v
+    extension (x: SubscriptionName) def value: String = x
+  }
 
   opaque type TopicName = String
-  def TopicName(v: String): TopicName = v
-  extension (x: TopicName)
-    @targetName("value_TopicName")
-    def value: String = x
+  object TopicName {
+    def apply(v: String): TopicName = v
+    extension (x: TopicName) def value: String = x
+  }
 
   opaque type TopicNamePattern = Regex
-  def TopicNamePattern(v: Regex): TopicNamePattern = v
-  extension (x: TopicNamePattern)
-    @targetName("value_TopicNamePattern")
-    def value: Regex = x
+  object TopicNamePattern {
+    def apply(v: Regex): TopicNamePattern = v
+    extension (x: TopicNamePattern) def value: Regex = x
+  }
 
   opaque type TopicURL = String
-  def TopicURL(v: String): TopicURL = v
-  extension (x: TopicURL)
-    @targetName("value_TopicURL")
-    def value: String = x
+  object TopicURL {
+    def apply(v: String): TopicURL = v
+    extension (x: TopicURL) def value: String = x
+  }
 
   object context:
     final case class Tenant(value: String)

--- a/core/src/main/scala-3/cr/pulsar/data.scala
+++ b/core/src/main/scala-3/cr/pulsar/data.scala
@@ -20,59 +20,32 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
 
 object data:
-  opaque type OperationTimeout = FiniteDuration
-  object OperationTimeout {
-    def apply(v: FiniteDuration): OperationTimeout = v
-    extension (x: OperationTimeout) def value: FiniteDuration = x
-  }
+  val OperationTimeout = NewType.of[FiniteDuration]
+  type OperationTimeout = OperationTimeout.Type
 
-  opaque type ConnectionTimeout = FiniteDuration
-  object ConnectionTimeout {
-    def apply(v: FiniteDuration): ConnectionTimeout = v
-    extension (x: ConnectionTimeout) def value: FiniteDuration = x
-  }
+  val ConnectionTimeout = NewType.of[FiniteDuration]
+  type ConnectionTimeout = ConnectionTimeout.Type
 
-  opaque type PulsarTenant = String
-  object PulsarTenant {
-    def apply(v: String): PulsarTenant = v
-    extension (x: PulsarTenant) def value: String = x
-  }
+  val PulsarTenant = NewType.of[String]
+  type PulsarTenant = PulsarTenant.Type
 
-  opaque type PulsarNamespace = String
-  object PulsarNamespace {
-    def apply(v: String): PulsarNamespace = v
-    extension (x: PulsarNamespace) def value: String = x
-  }
+  val PulsarNamespace = NewType.of[String]
+  type PulsarNamespace = PulsarNamespace.Type
 
-  opaque type PulsarURL = String
-  object PulsarURL {
-    def apply(v: String): PulsarURL = v
-    extension (x: PulsarURL) def value: String = x
-  }
+  val PulsarURL = NewType.of[String]
+  type PulsarURL = PulsarURL.Type
 
-  opaque type SubscriptionName = String
-  object SubscriptionName {
-    def apply(v: String): SubscriptionName = v
-    extension (x: SubscriptionName) def value: String = x
-  }
+  val SubscriptionName = NewType.of[String]
+  type SubscriptionName = SubscriptionName.Type
 
-  opaque type TopicName = String
-  object TopicName {
-    def apply(v: String): TopicName = v
-    extension (x: TopicName) def value: String = x
-  }
+  val TopicName = NewType.of[String]
+  type TopicName = TopicName.Type
 
-  opaque type TopicNamePattern = Regex
-  object TopicNamePattern {
-    def apply(v: Regex): TopicNamePattern = v
-    extension (x: TopicNamePattern) def value: Regex = x
-  }
+  val TopicNamePattern = NewType.of[Regex]
+  type TopicNamePattern = TopicNamePattern.Type
 
-  opaque type TopicURL = String
-  object TopicURL {
-    def apply(v: String): TopicURL = v
-    extension (x: TopicURL) def value: String = x
-  }
+  val TopicURL = NewType.of[String]
+  type TopicURL = TopicURL.Type
 
   object context:
     final case class Tenant(value: String)

--- a/core/src/main/scala-3/cr/pulsar/data.scala
+++ b/core/src/main/scala-3/cr/pulsar/data.scala
@@ -16,27 +16,66 @@
 
 package cr.pulsar
 
+import scala.annotation.targetName
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
 
-object data {
-  //opaque type Bar = Int
-  //opaque type Foo = String
+object data:
+  opaque type OperationTimeout = FiniteDuration
+  def OperationTimeout(v: FiniteDuration): OperationTimeout = v
+  extension (x: OperationTimeout)
+    @targetName("value_OperationTimeout")
+    def value: FiniteDuration = x
 
-  case class OperationTimeout(value: FiniteDuration)
-  case class ConnectionTimeout(value: FiniteDuration)
+  opaque type ConnectionTimeout = FiniteDuration
+  def ConnectionTimeout(v: FiniteDuration): ConnectionTimeout = v
+  extension (x: ConnectionTimeout)
+    @targetName("value_ConnectionTimeout")
+    def value: FiniteDuration = x
 
-  case class PulsarTenant(value: String)
-  case class PulsarNamespace(value: String)
-  case class PulsarURL(value: String)
+  opaque type PulsarTenant = String
+  def PulsarTenant(v: String): PulsarTenant = v
+  extension (x: PulsarTenant)
+    @targetName("value_PulsarTenant")
+    def value: String = x
 
-  case class SubscriptionName(value: String)
+  opaque type PulsarNamespace = String
+  def PulsarNamespace(v: String): PulsarNamespace = v
+  extension (x: PulsarNamespace)
+    @targetName("value_PulsarNamespace")
+    def value: String = x
 
-  case class TopicName(value: String)
-  case class TopicNamePattern(value: Regex)
-  case class TopicURL(value: String)
+  opaque type PulsarURL = String
+  def PulsarURL(v: String): PulsarURL = v
+  extension (x: PulsarURL)
+    @targetName("value_PulsarURL")
+    def value: String = x
 
-  object context {
+  opaque type SubscriptionName = String
+  def SubscriptionName(v: String): SubscriptionName = v
+  extension (x: SubscriptionName)
+    @targetName("value_SubscriptionName")
+    def value: String = x
+
+  opaque type TopicName = String
+  def TopicName(v: String): TopicName = v
+  extension (x: TopicName)
+    @targetName("value_TopicName")
+    def value: String = x
+
+  opaque type TopicNamePattern = Regex
+  def TopicNamePattern(v: Regex): TopicNamePattern = v
+  extension (x: TopicNamePattern)
+    @targetName("value_TopicNamePattern")
+    def value: Regex = x
+
+  opaque type TopicURL = String
+  def TopicURL(v: String): TopicURL = v
+  extension (x: TopicURL)
+    @targetName("value_TopicURL")
+    def value: String = x
+
+  object context:
     final case class Tenant(value: String)
     final case class Namespace(value: String)
     final case class FunctionName(value: String)
@@ -47,18 +86,5 @@ object data {
     final case class InputTopic(value: String)
     final case class OutputTopic(value: String)
     final case class OutputSchemaType(value: String)
-  }
-  //opaque type PulsarTenant = String
-  //opaque type PulsarNamespace = String
-  //opaque type PulsarURL = String
-
-  //extension (x: PulsarTenant) {
-  //def value: String = x
-  //}
-  //extension (x: PulsarNamespace) {
-  //def value: String = x
-  //}
-  //extension (x: PulsarURL) {
-  //def value: String = x
-  //}
-}
+  end context
+end data

--- a/core/src/main/scala-3/cr/pulsar/data.scala
+++ b/core/src/main/scala-3/cr/pulsar/data.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
+
+object data {
+  //opaque type Bar = Int
+  //opaque type Foo = String
+
+  case class OperationTimeout(value: FiniteDuration)
+  case class ConnectionTimeout(value: FiniteDuration)
+
+  case class PulsarTenant(value: String)
+  case class PulsarNamespace(value: String)
+  case class PulsarURL(value: String)
+
+  case class SubscriptionName(value: String)
+
+  case class TopicName(value: String)
+  case class TopicNamePattern(value: Regex)
+  case class TopicURL(value: String)
+
+  object context {
+    final case class Tenant(value: String)
+    final case class Namespace(value: String)
+    final case class FunctionName(value: String)
+    final case class FunctionId(value: String)
+    final case class InstanceId(value: Int)
+    final case class NumInstances(value: Int)
+    final case class FunctionVersion(value: String)
+    final case class InputTopic(value: String)
+    final case class OutputTopic(value: String)
+    final case class OutputSchemaType(value: String)
+  }
+  //opaque type PulsarTenant = String
+  //opaque type PulsarNamespace = String
+  //opaque type PulsarURL = String
+
+  //extension (x: PulsarTenant) {
+  //def value: String = x
+  //}
+  //extension (x: PulsarNamespace) {
+  //def value: String = x
+  //}
+  //extension (x: PulsarURL) {
+  //def value: String = x
+  //}
+}

--- a/core/src/main/scala-3/cr/pulsar/newtype.scala
+++ b/core/src/main/scala-3/cr/pulsar/newtype.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+import scala.compiletime.erasedValue
+import scala.concurrent.duration.FiniteDuration
+
+object NewType:
+  class GenNewType[A]:
+    opaque type Type = A
+    def apply(a: A): Type = a
+    extension (a: Type) def value: A = a
+  end GenNewType
+
+  class NewTypeBool extends GenNewType[Boolean]:
+    override opaque type Type = Boolean
+    override def apply(a: Boolean): Type = a
+    extension (a: Type) override def value: Boolean = a
+  end NewTypeBool
+
+  class NewTypeDouble extends GenNewType[Double]:
+    override opaque type Type = Double
+    override def apply(a: Double): Type = a
+    extension (a: Type) override def value: Double = a
+  end NewTypeDouble
+
+  class NewTypeInt extends GenNewType[Int]:
+    override opaque type Type = Int
+    override def apply(a: Int): Type = a
+    extension (a: Type) override def value: Int = a
+  end NewTypeInt
+
+  class NewTypeLong extends GenNewType[Long]:
+    override opaque type Type = Long
+    override def apply(a: Long): Type = a
+    extension (a: Type) override def value: Long = a
+  end NewTypeLong
+
+  class NewTypeString extends GenNewType[String]:
+    override opaque type Type = String
+    override def apply(a: String): Type = a
+    extension (a: Type) override def value: String = a
+  end NewTypeString
+
+  class NewTypeFiniteDuration extends GenNewType[FiniteDuration]:
+    override opaque type Type = FiniteDuration
+    override def apply(a: FiniteDuration): Type = a
+    extension (a: Type) override def value: FiniteDuration = a
+  end NewTypeFiniteDuration
+
+  transparent inline def of[A] = inline erasedValue[A] match {
+    case _: Boolean        => new NewTypeBool
+    case _: Double         => new NewTypeDouble
+    case _: FiniteDuration => new NewTypeFiniteDuration
+    case _: Int            => new NewTypeInt
+    case _: Long           => new NewTypeLong
+    case _: String         => new NewTypeString
+    case _                 => new GenNewType[A]
+  }
+end NewType

--- a/core/src/main/scala/cr/pulsar/Config.scala
+++ b/core/src/main/scala/cr/pulsar/Config.scala
@@ -47,24 +47,15 @@ object Config {
       _tenant: PulsarTenant = PulsarTenant(""),
       _namespace: PulsarNamespace = PulsarNamespace(""),
       _url: PulsarURL = PulsarURL("")
-  ) {
+  ) extends ConfigBuilderExtra[I] {
     def withTenant(tenant: PulsarTenant): ConfigBuilder[I with Info.Tenant] =
       this.copy(_tenant = tenant)
-
-    def withTenant(tenant: String): ConfigBuilder[I with Info.Tenant] =
-      withTenant(PulsarTenant(tenant))
 
     def withNameSpace(namespace: PulsarNamespace): ConfigBuilder[I with Info.Namespace] =
       this.copy(_namespace = namespace)
 
-    def withNameSpace(namespace: String): ConfigBuilder[I with Info.Namespace] =
-      withNameSpace(PulsarNamespace(namespace))
-
     def withURL(url: PulsarURL): ConfigBuilder[I with Info.URL] =
       this.copy(_url = url)
-
-    def withURL(url: String): ConfigBuilder[I with Info.URL] =
-      withURL(PulsarURL(url))
 
     /**
       * It creates a new configuration.

--- a/core/src/main/scala/cr/pulsar/Config.scala
+++ b/core/src/main/scala/cr/pulsar/Config.scala
@@ -16,8 +16,8 @@
 
 package cr.pulsar
 
-import Config._
-import io.estatico.newtype.macros._
+import cr.pulsar.data._
+
 import scala.annotation.implicitNotFound
 
 /**
@@ -31,9 +31,6 @@ sealed abstract class Config {
 }
 
 object Config {
-  @newtype case class PulsarTenant(value: String)
-  @newtype case class PulsarNamespace(value: String)
-  @newtype case class PulsarURL(value: String)
 
   /**************** Type-level builder ******************/
   sealed trait Info

--- a/core/src/main/scala/cr/pulsar/MessageKey.scala
+++ b/core/src/main/scala/cr/pulsar/MessageKey.scala
@@ -21,10 +21,10 @@ import cats.Eq
 sealed trait MessageKey
 object MessageKey {
   final case class Of(value: String) extends MessageKey
-  final case object Empty extends MessageKey
+  case object Empty extends MessageKey
 
   def apply(value: String): MessageKey =
-    Option(value).filter(_.trim.nonEmpty).map(Of).getOrElse(Empty)
+    Option(value).filter(_.trim.nonEmpty).map(Of(_)).getOrElse(Empty)
 
   implicit val eq: Eq[MessageKey] = Eq.fromUniversalEquals
 }

--- a/core/src/main/scala/cr/pulsar/Pulsar.scala
+++ b/core/src/main/scala/cr/pulsar/Pulsar.scala
@@ -16,17 +16,15 @@
 
 package cr.pulsar
 
-import cats.effect.{ Resource, Sync }
-import cr.pulsar.Pulsar.Options.{ ConnectionTimeout, OperationTimeout }
-import io.estatico.newtype.macros.newtype
-import org.apache.pulsar.client.api.{ PulsarClient => Underlying }
 import scala.concurrent.duration._
 
-import scala.concurrent.duration.FiniteDuration
+import cr.pulsar.data._
+import cr.pulsar.internal._
+
+import cats.effect.{ Resource, Sync }
+import org.apache.pulsar.client.api.{ PulsarClient => Underlying }
 
 object Pulsar {
-  import Config._
-
   type T = Underlying
 
   /**
@@ -79,9 +77,6 @@ object Pulsar {
   }
 
   object Options {
-    @newtype case class OperationTimeout(value: FiniteDuration)
-    @newtype case class ConnectionTimeout(value: FiniteDuration)
-
     private case class OptionsImpl(
         connectionTimeout: ConnectionTimeout,
         operationTimeout: OperationTimeout

--- a/core/src/main/scala/cr/pulsar/Reader.scala
+++ b/core/src/main/scala/cr/pulsar/Reader.scala
@@ -16,18 +16,18 @@
 
 package cr.pulsar
 
-import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
+
+import cr.pulsar.Reader.Message
+import cr.pulsar.internal._
+import cr.pulsar.internal.FutureLift._
 
 import cats._
 import cats.effect._
 import cats.syntax.all._
-import cr.pulsar.Reader.Message
-import cr.pulsar.internal.FutureLift._
 import fs2._
 import org.apache.pulsar.client.api.{ MessageId, Reader => JReader }
-
-import scala.concurrent.duration.FiniteDuration
-import scala.util.control.NoStackTrace
 
 /**
   * A MessageReader can be used to read all the messages currently available in a topic.

--- a/core/src/main/scala/cr/pulsar/ShardKey.scala
+++ b/core/src/main/scala/cr/pulsar/ShardKey.scala
@@ -21,7 +21,7 @@ import cats.Eq
 sealed trait ShardKey
 object ShardKey {
   final case class Of(value: Array[Byte]) extends ShardKey
-  final case object Default extends ShardKey
+  case object Default extends ShardKey
 
   implicit val eq: Eq[ShardKey] = Eq.fromUniversalEquals
 }

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -16,12 +16,14 @@
 
 package cr.pulsar
 
-import io.estatico.newtype.macros.newtype
-import org.apache.pulsar.client.api.{ SubscriptionMode, SubscriptionType }
 import scala.annotation.implicitNotFound
 
+import cr.pulsar.data._
+
+import org.apache.pulsar.client.api.{ SubscriptionMode, SubscriptionType }
+
 sealed abstract class Subscription {
-  val name: Subscription.Name
+  val name: SubscriptionName
   val `type`: Subscription.Type
   val mode: Subscription.Mode
 }
@@ -37,8 +39,6 @@ sealed abstract class Subscription {
   * Find out more at [[https://pulsar.apache.org/docs/en/concepts-messaging/#subscriptions]]
   */
 object Subscription {
-  @newtype case class Name(value: String)
-
   sealed trait Mode {
     def pulsarSubscriptionMode: SubscriptionMode
   }
@@ -83,15 +83,15 @@ object Subscription {
   }
 
   case class SubscriptionBuilder[I <: Info] protected (
-      _name: Name = Name(""),
+      _name: SubscriptionName = SubscriptionName(""),
       _type: Type = Type.Exclusive,
       _mode: Mode = Mode.Durable
   ) {
-    def withName(name: Name): SubscriptionBuilder[I with Info.Name] =
-      this.copy(_name = Name(s"${name.value}-subscription"))
+    def withName(name: SubscriptionName): SubscriptionBuilder[I with Info.Name] =
+      this.copy(_name = SubscriptionName(s"${name.value}-subscription"))
 
     def withName(name: String): SubscriptionBuilder[I with Info.Name] =
-      withName(Name(name))
+      withName(SubscriptionName(name))
 
     def withMode(mode: Mode): SubscriptionBuilder[I with Info.Mode] =
       this.copy(_mode = mode)

--- a/core/src/main/scala/cr/pulsar/Subscription.scala
+++ b/core/src/main/scala/cr/pulsar/Subscription.scala
@@ -86,12 +86,9 @@ object Subscription {
       _name: SubscriptionName = SubscriptionName(""),
       _type: Type = Type.Exclusive,
       _mode: Mode = Mode.Durable
-  ) {
+  ) extends SubscriptionBuilderExtra[I] {
     def withName(name: SubscriptionName): SubscriptionBuilder[I with Info.Name] =
       this.copy(_name = SubscriptionName(s"${name.value}-subscription"))
-
-    def withName(name: String): SubscriptionBuilder[I with Info.Name] =
-      withName(SubscriptionName(name))
 
     def withMode(mode: Mode): SubscriptionBuilder[I with Info.Mode] =
       this.copy(_mode = mode)

--- a/core/src/main/scala/cr/pulsar/Topic.scala
+++ b/core/src/main/scala/cr/pulsar/Topic.scala
@@ -17,7 +17,6 @@
 package cr.pulsar
 
 import scala.annotation.implicitNotFound
-import scala.util.matching.Regex
 
 import cr.pulsar.data._
 
@@ -87,18 +86,12 @@ object Topic {
       _pattern: TopicNamePattern = TopicNamePattern("".r),
       _config: Config = Config.Builder.default,
       _type: Type = Type.Persistent
-  ) {
+  ) extends TopicBuilderExtra[I] {
     def withName(name: TopicName): TopicBuilder[I with Info.Name] =
       this.copy(_name = name)
 
-    def withName(name: String): TopicBuilder[I with Info.Name] =
-      withName(TopicName(name))
-
     def withNamePattern(pattern: TopicNamePattern): TopicBuilder[I with Info.Pattern] =
       this.copy(_pattern = pattern)
-
-    def withNamePattern(regex: Regex): TopicBuilder[I with Info.Pattern] =
-      withNamePattern(TopicNamePattern(regex))
 
     def withConfig(config: Config): TopicBuilder[I with Info.Config] =
       this.copy(_config = config)

--- a/core/src/main/scala/cr/pulsar/internal/FutureLift.scala
+++ b/core/src/main/scala/cr/pulsar/internal/FutureLift.scala
@@ -54,7 +54,7 @@ object FutureLift {
           F.delay(f.cancel(true)).void
         }
       }
-    lifted.guarantee(F.shift)
+    lifted.guarantee(ContextShift[F].shift)
   }
 
 }

--- a/core/src/main/scala/cr/pulsar/internal/package.scala
+++ b/core/src/main/scala/cr/pulsar/internal/package.scala
@@ -16,6 +16,23 @@
 
 package cr.pulsar
 
-import scala.collection.convert.{ DecorateAsJava, DecorateAsScala }
+import cats.Inject
+import cats.effect.Bracket
 
-object JavaConversions extends DecorateAsJava with DecorateAsScala
+package object internal {
+
+  /**
+    * A convenient dependent summoner for the Cats Effect hierarchy. Inspired by izumi's BIO.
+    * Auto-narrows to the most powerful available class but it does not work below Monad (ambiguous implicits).
+    *
+    * {{{
+    *   import cr.pulsar.internal.summoner.F
+    *
+    *   def program[F[_]: Sync]: F[Unit] =
+    *     F.delay(println("Hello world!"))
+    * }}}
+    */
+  @inline final def F[FR[_]](implicit FR: Bracket[FR, Throwable]): FR.type = FR
+
+  @inline final def E[T](implicit T: Inject[T, Array[Byte]]): T.type = T
+}

--- a/function/src/main/scala-2.13/cr/pulsar/data.scala
+++ b/function/src/main/scala-2.13/cr/pulsar/data.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Chatroulette
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cr.pulsar
+
+//import io.estatico.newtype.macros._
+
+object data {
+  case class Tenant(value: String)
+  case class Namespace(value: String)
+  case class FunctionName(value: String)
+  case class FunctionId(value: String)
+  case class InstanceId(value: Int)
+  case class NumInstances(value: Int)
+  case class FunctionVersion(value: String)
+  case class InputTopic(value: String)
+  case class OutputTopic(value: String)
+  case class OutputSchemaType(value: String)
+
+  // getting these errors with newtype on scala 2.13.x, not sure why, it works in the core module
+  // [error] /home/gvolpe/workspace/cr/neutron/function/src/main/scala-2.13/cr/pulsar/data.scala:22:23: macro annotation could not be expanded (you cannot use a macro annotation in the same compilation run that defines it)
+  // [error]   @newtype case class Tenant(value: String)
+  //
+  //@newtype case class Tenant(value: String)
+  //@newtype case class Namespace(value: String)
+  //@newtype case class FunctionName(value: String)
+  //@newtype case class FunctionId(value: String)
+  //@newtype case class InstanceId(value: Int)
+  //@newtype case class NumInstances(value: Int)
+  //@newtype case class FunctionVersion(value: String)
+  //@newtype case class InputTopic(value: String)
+  //@newtype case class OutputTopic(value: String)
+  //@newtype case class OutputSchemaType(value: String)
+}

--- a/function/src/main/scala-3/cr/pulsar/data.scala
+++ b/function/src/main/scala-3/cr/pulsar/data.scala
@@ -16,6 +16,15 @@
 
 package cr.pulsar
 
-import scala.collection.convert.{ AsJavaExtensions, AsScalaExtensions }
-
-object JavaConversions extends AsJavaExtensions with AsScalaExtensions
+object data {
+  case class Tenant(value: String)
+  case class Namespace(value: String)
+  case class FunctionName(value: String)
+  case class FunctionId(value: String)
+  case class InstanceId(value: Int)
+  case class NumInstances(value: Int)
+  case class FunctionVersion(value: String)
+  case class InputTopic(value: String)
+  case class OutputTopic(value: String)
+  case class OutputSchemaType(value: String)
+}

--- a/function/src/main/scala/cr/pulsar/Context.scala
+++ b/function/src/main/scala/cr/pulsar/Context.scala
@@ -18,14 +18,15 @@ package cr.pulsar
 
 import java.nio.ByteBuffer
 
-import cr.pulsar.WindowContext._
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
+import scala.reflect.ClassTag
+
+import cr.pulsar.data._
+
 import org.apache.pulsar.client.api.{ Schema, TypedMessageBuilder }
 import org.apache.pulsar.functions.api.{ Context => JavaContext }
 import org.slf4j.Logger
-
-import cr.pulsar.JavaConversions._
-import scala.compat.java8.OptionConverters._
-import scala.reflect.ClassTag
 
 final case class Context(private val ctx: JavaContext) {
   def tenant: Tenant                     = Tenant(ctx.getTenant)
@@ -49,7 +50,7 @@ final case class Context(private val ctx: JavaContext) {
 
   def userConfigMap: Map[String, AnyRef] = ctx.getUserConfigMap.asScala.toMap
   def userConfigValue[T: ClassTag](key: String): Option[T] =
-    ctx.getUserConfigValue(key).asScala.collect { case x: T => x }
+    ctx.getUserConfigValue(key).toScala.collect { case x: T => x }
 
   def userConfigValueOrElse[T: ClassTag](key: String, defaultValue: T): T =
     userConfigValue[T](key).getOrElse(defaultValue)

--- a/function/src/main/scala/cr/pulsar/Record.scala
+++ b/function/src/main/scala/cr/pulsar/Record.scala
@@ -16,23 +16,23 @@
 
 package cr.pulsar
 
-import cr.pulsar.JavaConversions._
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
+
 import org.apache.pulsar.client.api.Message
 import org.apache.pulsar.functions.api.{ Record => JavaRecord }
-
-import scala.compat.java8.OptionConverters._
 
 final case class Record[T](private val ctx: JavaRecord[T]) {
   def ack(): Unit  = ctx.ack()
   def fail(): Unit = ctx.fail()
 
-  def destinationTopic: Option[String] = ctx.getDestinationTopic.asScala
-  def eventTime: Option[Long]          = ctx.getEventTime.asScala.map(x => x)
-  def key: Option[String]              = ctx.getKey.asScala
-  def message: Option[Message[T]]      = ctx.getMessage.asScala
-  def partitionId: Option[String]      = ctx.getPartitionId.asScala
+  def destinationTopic: Option[String] = ctx.getDestinationTopic.toScala
+  def eventTime: Option[Long]          = ctx.getEventTime.toScala.map(x => x)
+  def key: Option[String]              = ctx.getKey.toScala
+  def message: Option[Message[T]]      = ctx.getMessage.toScala
+  def partitionId: Option[String]      = ctx.getPartitionId.toScala
   def properties: Map[String, String]  = ctx.getProperties.asScala.toMap
-  def recordSequence: Option[Long]     = ctx.getRecordSequence.asScala.map(x => x)
-  def topicName: Option[String]        = ctx.getTopicName.asScala
+  def recordSequence: Option[Long]     = ctx.getRecordSequence.toScala.map(x => x)
+  def topicName: Option[String]        = ctx.getTopicName.toScala
   def value: T                         = ctx.getValue
 }

--- a/function/src/test/scala/cr/pulsar/FunctionInput.scala
+++ b/function/src/test/scala/cr/pulsar/FunctionInput.scala
@@ -21,6 +21,8 @@ import java.{ lang, util }
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.pulsar.client.api.{ ConsumerBuilder, Schema, TypedMessageBuilder }
 import org.apache.pulsar.functions.api.{
   Context => JavaContext,
@@ -28,7 +30,6 @@ import org.apache.pulsar.functions.api.{
   WindowContext => JavaWindowContext
 }
 import org.slf4j.Logger
-import cr.pulsar.JavaConversions._
 
 object FunctionInput {
   def emptyWindowCtx: JavaWindowContext = new JavaWindowContext {

--- a/function/src/test/scala/cr/pulsar/FunctionSpec.scala
+++ b/function/src/test/scala/cr/pulsar/FunctionSpec.scala
@@ -23,7 +23,7 @@ import org.scalacheck.Prop._
 
 class FunctionSpec extends ScalaCheckSuite {
   property("Function can convert numbers to strings") {
-    forAll { n: Int =>
+    forAll { (n: Int) =>
       val f = new Function[Int, String] {
         override def handle(input: Int, ctx: Context): String =
           input.toString
@@ -35,7 +35,7 @@ class FunctionSpec extends ScalaCheckSuite {
   }
 
   property("Function can do side effects") {
-    forAll { n: Int =>
+    forAll { (n: Int) =>
       var i = 0
       val f = new Function[Int, Unit] {
         override def handle(input: Int, ctx: Context): Unit =

--- a/function/src/test/scala/cr/pulsar/WindowContextSpec.scala
+++ b/function/src/test/scala/cr/pulsar/WindowContextSpec.scala
@@ -21,18 +21,19 @@ import java.util
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
-import cats.syntax.all._
-import cr.pulsar.WindowContext.OutputTopic
-import munit.ScalaCheckSuite
-import org.apache.pulsar.functions.api.{ WindowContext => JavaWindowContext }
-import org.scalacheck.Prop._
-import org.slf4j.Logger
-
 import scala.collection.mutable
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
+
+import cr.pulsar.data.OutputTopic
+
+import cats.syntax.all._
+import munit.ScalaCheckSuite
+import org.apache.pulsar.functions.api.{ WindowContext => JavaWindowContext }
+import org.scalacheck.Prop._
+import org.slf4j.Logger
 
 class WindowContextSpec extends ScalaCheckSuite {
   property("WindowContext mapping of fields is correct") {
@@ -313,7 +314,7 @@ class WindowContextSpec extends ScalaCheckSuite {
 
         val ctx = new WindowContext(javaCtx)
 
-        assert(ctx.userConfigValue(key).isEmpty)
+        assert((ctx.userConfigValue(key): Option[Int]).isEmpty)
         assert(ctx.userConfigValueOrElse(key, defaultValue) === defaultValue)
 
         map.put(key, Integer.valueOf(value))
@@ -334,7 +335,7 @@ class WindowContextSpec extends ScalaCheckSuite {
         var i = 0
 
         def publishMessage: CompletableFuture[Void] =
-          Future({ i = i + 1 }).toJava.toCompletableFuture
+          Future({ i = i + 1 }).asJava.toCompletableFuture
             .thenApply(_ => null) // converting to void
 
         val javaCtx = new JavaWindowContext {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,20 +3,16 @@ import sbt._
 object Dependencies {
 
   object V {
-    val java8Compat = "0.9.1"
-
     val cats       = "2.3.1"
     val catsEffect = "2.3.1"
-    val circe      = "0.13.0"
+    val circe      = "0.14.0-M2"
     val fs2        = "2.5.0"
     val munit      = "0.7.20"
     val newtype    = "0.4.4"
     val pulsar     = "2.6.2"
 
     val betterMonadicFor = "0.3.1"
-    val contextApplied   = "0.1.4"
     val kindProjector    = "0.11.3"
-    val macroParadise    = "2.1.1"
   }
 
   object Libraries {
@@ -27,8 +23,6 @@ object Dependencies {
 
     val circeCore   = "io.circe" %% "circe-core"   % V.circe
     val circeParser = "io.circe" %% "circe-parser" % V.circe
-
-    val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat
 
     val pulsar             = "org.apache.pulsar" % "pulsar-client"        % V.pulsar
     val pulsarFunctionsApi = "org.apache.pulsar" % "pulsar-functions-api" % V.pulsar
@@ -42,14 +36,8 @@ object Dependencies {
     val betterMonadicFor = compilerPlugin(
       "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor
     )
-    val contextApplied = compilerPlugin(
-      "org.augustjune" %% "context-applied" % V.contextApplied
-    )
     val kindProjector = compilerPlugin(
       "org.typelevel" %% "kind-projector" % V.kindProjector cross CrossVersion.full
-    )
-    val macroParadise = compilerPlugin(
-      "org.scalamacros" % "paradise" % V.macroParadise cross CrossVersion.full
     )
   }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,12 +6,10 @@ import Dependencies.CompilerPlugins
 
 object Settings {
   val commonSettings = Seq(
-    scalacOptions ++= compilerFlags(scalaVersion.value),
     scalafmtOnCompile := true,
     autoAPIMappings := true,
     testFrameworks += new TestFramework("munit.Framework"),
-    libraryDependencies ++= macroParadisePlugin(scalaVersion.value),
-    ThisBuild / crossScalaVersions := Seq("2.13.2"),
+    ThisBuild / crossScalaVersions := Seq("2.13.4", "3.0.0-M3"),
     ThisBuild / homepage := Some(url("https://github.com/cr-org/neutron")),
     ThisBuild / organization := "com.chatroulette",
     ThisBuild / organizationName := "Chatroulette",
@@ -61,11 +59,5 @@ object Settings {
     CrossVersion.partialVersion(v) match {
       case Some((2, 13)) => List("-Ymacro-annotations")
       case _             => List.empty
-    }
-
-  def macroParadisePlugin(v: String) =
-    CrossVersion.partialVersion(v) match {
-      case Some((2, 13)) => List.empty
-      case _             => List(CompilerPlugins.macroParadise)
     }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,4 @@ addSbtPlugin("org.scalameta"             % "sbt-mdoc"                   % "2.2.1
 addSbtPlugin("com.lightbend.paradox"     % "sbt-paradox"                % "0.9.1")
 addSbtPlugin("io.github.jonas"           % "sbt-paradox-material-theme" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-site"                   % "1.3.3")
+addSbtPlugin("ch.epfl.lamp"              % "sbt-dotty"                  % "0.5.1")


### PR DESCRIPTION
It was painful but I got it working. Things that still should be improved:

- ~Opaque types don't compile, I've no idea why so I just used plain `case class`es for now.~
- Newtypes defined in the `function` module don't compile either, don't know why, the same works in the `core` module.
- Replaced `context-applied` with a simpler summoner but that only works for the Cats Effect typeclass hierarchy. Cats Core typeclasses are not supported, get ambiguous implicits errors. 

Worth mentioning:

- Removed the `java8-compat` dep, no longer needed.