### PR TITLE
Consumer action on decoding failure

### DIFF
--- a/core/src/it/scala/cr/pulsar/PulsarSpec.scala
+++ b/core/src/it/scala/cr/pulsar/PulsarSpec.scala
@@ -16,12 +16,14 @@
 
 package cr.pulsar
 
-import cats.effect._
-import cats.effect.concurrent.{Deferred, Ref}
-import cats.implicits._
-import cr.pulsar.schema.utf8._
-import fs2.Stream
 import java.util.UUID
+
+import cr.pulsar.schema.utf8._
+
+import cats.effect._
+import cats.effect.concurrent.{ Deferred, Ref }
+import cats.implicits._
+import fs2.Stream
 
 class PulsarSpec extends PulsarSuite {
 
@@ -42,11 +44,12 @@ class PulsarSpec extends PulsarSuite {
 
   withPulsarClient { client =>
     test("A message is published and consumed successfully") {
+      val hpTopic = topic("happy-path")
+
       val res: Resource[IO, (Consumer[IO, Event], Producer[IO, Event])] =
         for {
-          consumer <- Consumer
-                       .create[IO, Event](client, topic("happy-path"), sub("happy-path"))
-          producer <- Producer.create[IO, Event](client, topic("happy-path"))
+          consumer <- Consumer.create[IO, Event](client, hpTopic, sub("happy-path"))
+          producer <- Producer.create[IO, Event](client, hpTopic)
         } yield consumer -> producer
 
       Deferred[IO, Event].flatMap { latch =>
@@ -75,12 +78,13 @@ class PulsarSpec extends PulsarSuite {
       }
     }
 
-    test("A message is published and nack'ed when consumer fails to decode it") {
+    test("A consumer fails to decode a message") {
+      val dfTopic = topic("decoding-failure")
+
       val res: Resource[IO, (Consumer[IO, Event], Producer[IO, String])] =
         for {
-          consumer <- Consumer
-                       .create[IO, Event](client, topic("auto-nack"), sub("auto-nack"))
-          producer <- Producer.create[IO, String](client, topic("auto-nack"))
+          consumer <- Consumer.create[IO, Event](client, dfTopic, sub("decoding-failure"))
+          producer <- Producer.create[IO, String](client, dfTopic)
         } yield consumer -> producer
 
       Deferred[IO, Array[Byte]].flatMap { latch =>
@@ -110,6 +114,59 @@ class PulsarSpec extends PulsarSuite {
           .compile
           .drain
       }
+    }
+
+    test(
+      "A consumer fails to decode first message, which is acked and logged via onFailure, and continue to process more messages"
+    ) {
+      (
+        Deferred[IO, Either[Throwable, Unit]],
+        Ref.of[IO, Option[Event]](None),
+        Ref.of[IO, Option[Consumer.DecodingFailure]](None)
+      ).tupled
+        .flatMap {
+          case (latch, ref, logger) =>
+            val dfaTopic = topic("decoding-failure-acked-logged")
+
+            val opts = Consumer
+              .Options[IO, Event]()
+              .withOnFailure(
+                Consumer.OnFailure.Ack(e => logger.set(e.some))
+              )
+
+            val res: Resource[IO, (Consumer[IO, Event], Producer[IO, String])] =
+              for {
+                consumer <- Consumer.withOptions(client, dfaTopic, sub("err-acked"), opts)
+                producer <- Producer.create[IO, String](client, dfaTopic)
+              } yield consumer -> producer
+
+            Stream
+              .resource(res)
+              .flatMap {
+                case (consumer, producer) =>
+                  val consume: Stream[IO, Event] =
+                    consumer.autoSubscribe
+                      .evalTap(e => ref.set(e.some) >> latch.complete(().asRight))
+                      .interruptWhen(latch.get)
+
+                  val badMessage = "Consumer will fail to decode this message"
+                  val testEvent  = Event(UUID.randomUUID(), "test")
+
+                  val goodMessage = new String(Event.inject.inj(testEvent), "UTF-8")
+
+                  val produce =
+                    Stream(badMessage, goodMessage)
+                      .covary[IO]
+                      .evalMap(producer.send)
+
+                  consume.concurrently(produce).evalMap { _ =>
+                    logger.get.map(e => assert(e.nonEmpty)) >>
+                      ref.get.map(e => assertEquals(e, Some(testEvent)))
+                  }
+              }
+              .compile
+              .drain
+        }
     }
 
     test(
@@ -164,11 +221,15 @@ class PulsarSpec extends PulsarSuite {
                   val interrupter = {
                     val pred1: IO[Boolean] =
                       events1.get.map(
-                        _.forall(_.shardKey === ShardKey.Of(uuids(0).toString.getBytes(charset)))
+                        _.forall(
+                          _.shardKey === ShardKey.Of(uuids(0).toString.getBytes(charset))
+                        )
                       )
                     val pred2: IO[Boolean] =
                       events2.get.map(
-                        _.forall(_.shardKey === ShardKey.Of(uuids(1).toString.getBytes(charset)))
+                        _.forall(
+                          _.shardKey === ShardKey.Of(uuids(1).toString.getBytes(charset))
+                        )
                       )
                     Stream.eval((pred1, pred2).mapN { case (p1, p2) => p1 && p2 })
                   }


### PR DESCRIPTION
So we can decide whether we `ack`, `nack` or do nothing + running some action (e.g. logging the error) on decoding failure.