### PR TITLE
Use personal access token to trigger release on a new tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5.11.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PATH }}


### PR DESCRIPTION
Trying this out from https://github.community/t/triggering-a-new-workflow-from-another-workflow/16250/37