### PR TITLE
Revert use of GH_PATH over GITHUB_TOKEN for now

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5.13.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PATH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverting until we know whether it is possible to use a personal token: https://github.com/release-drafter/release-drafter/issues/768