### PR TITLE
Use personal access token to trigger releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5.13.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
I committed the mistake of setting it to `GH_PATH` instead of `GH_PAT` before, pretty sure that's why it didn't work :facepalm: 