### PR TITLE
Simplify constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Check out the [microsite](https://cr-org.github.io/neutron/).
 
 ### Pulsar version
 
-At the moment, we target Apache Pulsar 2.6.x.
+At the moment, we target Apache Pulsar 2.7.x.
 
 ### Development
 

--- a/circe/src/main/scala/cr/pulsar/schema/circe/package.scala
+++ b/circe/src/main/scala/cr/pulsar/schema/circe/package.scala
@@ -36,7 +36,7 @@ import org.apache.pulsar.client.api.schema.{
 
 package object circe {
 
-  implicit def circeInstance[T: ClassTag: Encoder: Decoder]: Schema[T] =
+  implicit def circeInstance[T: ClassTag: Decoder: Encoder]: Schema[T] =
     new Schema[T] {
       def schema: JSchema[T] = {
         val reader = new SchemaReader[T] {

--- a/core/src/main/scala/cr/pulsar/Pulsar.scala
+++ b/core/src/main/scala/cr/pulsar/Pulsar.scala
@@ -35,14 +35,10 @@ object Pulsar {
     * It will be closed once the client is no longer in use or in case of
     * shutdown of the application that makes use of it.
     */
-  def create[F[_]: Sync](
-      url: PulsarURL
-  ): Resource[F, T] = withOptions(url, Options())
-
-  def withOptions[F[_]: Sync](
+  def make[F[_]: Sync](
       url: PulsarURL,
-      opts: Options
-  ): Resource[F, Underlying] =
+      opts: Options = Options()
+  ): Resource[F, T] =
     Resource.fromAutoCloseable(
       F.delay(
         Underlying.builder

--- a/core/src/main/scala/cr/pulsar/Reader.scala
+++ b/core/src/main/scala/cr/pulsar/Reader.scala
@@ -52,7 +52,7 @@ object Reader {
 
   private def mkPulsarReader[F[_]: Sync](
       client: Pulsar.T,
-      topic: Topic,
+      topic: Topic.Single,
       opts: Options
   ): Resource[F, JReader[Array[Byte]]] =
     Resource
@@ -129,53 +129,29 @@ object Reader {
   /**
     * It creates a [[Reader]] with the supplied [[Options]].
     */
-  def withOptions[
+  def make[
       F[_]: Concurrent: ContextShift,
       E: Inject[*, Array[Byte]]
   ](
       client: Pulsar.T,
-      topic: Topic,
-      opts: Options
+      topic: Topic.Single,
+      opts: Options = Options()
   ): Resource[F, Reader[F, E]] =
     mkPulsarReader[F](client, topic, opts)
       .map(c => mkPayloadReader(mkMessageReader[F, E](c)))
 
   /**
-    * It creates a simple [[Reader]].
-    */
-  def create[
-      F[_]: Concurrent: ContextShift,
-      E: Inject[*, Array[Byte]]
-  ](
-      client: Pulsar.T,
-      topic: Topic
-  ): Resource[F, Reader[F, E]] =
-    withOptions[F, E](client, topic, Options())
-
-  /**
     * It creates a [[MessageReader]] with the supplied [[Options]].
-    */
-  def messageReaderWithOptions[
-      F[_]: Concurrent: ContextShift,
-      E: Inject[*, Array[Byte]]
-  ](
-      client: Pulsar.T,
-      topic: Topic,
-      opts: Options
-  ): Resource[F, MessageReader[F, E]] =
-    mkPulsarReader[F](client, topic, opts).map(mkMessageReader[F, E])
-
-  /**
-    * It creates a simple [[MessageReader]].
     */
   def messageReader[
       F[_]: Concurrent: ContextShift,
       E: Inject[*, Array[Byte]]
   ](
       client: Pulsar.T,
-      topic: Topic
+      topic: Topic.Single,
+      opts: Options = Options()
   ): Resource[F, MessageReader[F, E]] =
-    messageReaderWithOptions[F, E](client, topic, Options())
+    mkPulsarReader[F](client, topic, opts).map(mkMessageReader[F, E])
 
   // Builder-style abstract class instead of case class to allow for bincompat-friendly extension in future versions.
   sealed abstract class Options {

--- a/core/src/main/scala/cr/pulsar/Topic.scala
+++ b/core/src/main/scala/cr/pulsar/Topic.scala
@@ -116,7 +116,7 @@ object Topic {
       */
     def build(
         implicit @implicitNotFound(
-          "Topic.Name or Topic.Pattern, and Config are mandatory. By default Type=Persistent."
+          "Topic.Name and Config are mandatory. By default Type=Persistent."
         ) ev: I =:= Info.SingleMandatory
     ): Topic.Single = {
       val t = _name.swap.toOption.get
@@ -131,14 +131,12 @@ object Topic {
       */
     def buildMulti(
         implicit @implicitNotFound(
-          "Topic.Pattern, and Config are mandatory. By default Type=Persistent."
+          "Topic.Pattern and Config are mandatory. By default Type=Persistent."
         ) ev: I =:= Info.MultiMandatory
-    ): Topic.Multi = {
-      val m = _name.toOption.get
+    ): Topic.Multi =
       new Multi {
-        val url = buildRegexUrl(_config, m, _type)
+        val url = buildRegexUrl(_config, _name.toOption.get, _type)
       }
-    }
 
   }
 

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -43,9 +43,9 @@ object Demo extends IOApp {
 
   val resources: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
     for {
-      pulsar   <- Pulsar.create[IO](config.url)
-      consumer <- Consumer.create[IO, String](pulsar, topic, subs)
-      producer <- Producer.create[IO, String](pulsar, topic)
+      pulsar   <- Pulsar.make[IO](config.url)
+      consumer <- Consumer.make[IO, String](pulsar, topic, subs)
+      producer <- Producer.make[IO, String](pulsar, topic)
     } yield (consumer, producer)
 
   def run(args: List[String]): IO[ExitCode] =

--- a/tests/src/it/scala/cr/pulsar/AlwaysIncompatibleSchemaSuite.scala
+++ b/tests/src/it/scala/cr/pulsar/AlwaysIncompatibleSchemaSuite.scala
@@ -17,7 +17,7 @@ object AlwaysIncompatibleSchemaSuite extends IOSuite {
     .build
 
   override type Res = Pulsar.T
-  override def sharedResource: Resource[IO, Res] = Pulsar.create[IO](cfg.url)
+  override def sharedResource: Resource[IO, Res] = Pulsar.make[IO](cfg.url)
 
   val sub = (s: String) =>
     Subscription.Builder
@@ -38,8 +38,8 @@ object AlwaysIncompatibleSchemaSuite extends IOSuite {
   ) { client =>
     val res: Resource[IO, (Consumer[IO, Event], Producer[IO, Event_V2])] =
       for {
-        consumer <- Consumer.create[IO, Event](client, topic, sub("circe"))
-        producer <- Producer.create[IO, Event_V2](client, topic)
+        consumer <- Consumer.make[IO, Event](client, topic, sub("circe"))
+        producer <- Producer.make[IO, Event_V2](client, topic)
       } yield consumer -> producer
 
     res.attempt.use {

--- a/tests/src/it/scala/cr/pulsar/BackwardCompatSchemaSuite.scala
+++ b/tests/src/it/scala/cr/pulsar/BackwardCompatSchemaSuite.scala
@@ -20,7 +20,7 @@ object BackwardCompatSchemaSuite extends IOSuite {
     .build
 
   override type Res = Pulsar.T
-  override def sharedResource: Resource[IO, Res] = Pulsar.create[IO](cfg.url)
+  override def sharedResource: Resource[IO, Res] = Pulsar.make[IO](cfg.url)
 
   val sub = (s: String) =>
     Subscription.Builder
@@ -40,8 +40,8 @@ object BackwardCompatSchemaSuite extends IOSuite {
     client =>
       val res: Resource[IO, (Consumer[IO, Event_V2], Producer[IO, Event])] =
         for {
-          consumer <- Consumer.create[IO, Event_V2](client, topic, sub("circe"))
-          producer <- Producer.create[IO, Event](client, topic)
+          consumer <- Consumer.make[IO, Event_V2](client, topic, sub("circe"))
+          producer <- Producer.make[IO, Event](client, topic)
         } yield consumer -> producer
 
       (Ref.of[IO, Int](0), Deferred[IO, Event_V2]).tupled.flatMap {

--- a/tests/src/it/scala/cr/pulsar/NeutronSuite.scala
+++ b/tests/src/it/scala/cr/pulsar/NeutronSuite.scala
@@ -35,7 +35,7 @@ object NeutronSuite extends IOSuite {
   val cfg = Config.Builder.default
 
   override type Res = Pulsar.T
-  override def sharedResource: Resource[IO, Res] = Pulsar.create[IO](cfg.url)
+  override def sharedResource: Resource[IO, Res] = Pulsar.make[IO](cfg.url)
 
   val sub = (s: String) =>
     Subscription.Builder
@@ -58,8 +58,8 @@ object NeutronSuite extends IOSuite {
 
       val res: Resource[IO, (Consumer[IO, Event], Producer[IO, Event])] =
         for {
-          consumer <- Consumer.create[IO, Event](client, hpTopic, sub("hp-circe"))
-          producer <- Producer.create[IO, Event](client, hpTopic)
+          consumer <- Consumer.make[IO, Event](client, hpTopic, sub("hp-circe"))
+          producer <- Producer.make[IO, Event](client, hpTopic)
         } yield consumer -> producer
 
       Deferred[IO, Event].flatMap { latch =>
@@ -94,8 +94,8 @@ object NeutronSuite extends IOSuite {
 
       val res: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
         for {
-          consumer <- Consumer.create[IO, String](client, hpTopic, sub("hp-bytes"))
-          producer <- Producer.create[IO, String](client, hpTopic)
+          consumer <- Consumer.make[IO, String](client, hpTopic, sub("hp-bytes"))
+          producer <- Producer.make[IO, String](client, hpTopic)
         } yield consumer -> producer
 
       Deferred[IO, String].flatMap { latch =>
@@ -129,8 +129,8 @@ object NeutronSuite extends IOSuite {
 
     val res: Resource[IO, (Consumer[IO, Event], Producer[IO, String])] =
       for {
-        consumer <- Consumer.create[IO, Event](client, dfTopic, sub("decoding-err"))
-        producer <- Producer.create[IO, String](client, dfTopic)
+        consumer <- Consumer.make[IO, Event](client, dfTopic, sub("decoding-err"))
+        producer <- Producer.make[IO, String](client, dfTopic)
       } yield consumer -> producer
 
     Deferred[IO, String].flatMap { latch =>
@@ -179,9 +179,9 @@ object NeutronSuite extends IOSuite {
         (Consumer[IO, Event], Consumer[IO, Event], Producer[IO, Event])
       ] =
         for {
-          c1 <- Consumer.create[IO, Event](client, topic("shared"), makeSub("s1"))
-          c2 <- Consumer.create[IO, Event](client, topic("shared"), makeSub("s2"))
-          p1 <- Producer.withOptions(client, topic("shared"), opts)
+          c1 <- Consumer.make[IO, Event](client, topic("shared"), makeSub("s1"))
+          c2 <- Consumer.make[IO, Event](client, topic("shared"), makeSub("s2"))
+          p1 <- Producer.make(client, topic("shared"), opts)
         } yield (c1, c2, p1)
 
       (Ref.of[IO, List[Event]](List.empty), Ref.of[IO, List[Event]](List.empty)).tupled
@@ -241,8 +241,8 @@ object NeutronSuite extends IOSuite {
 
     val res: Resource[IO, (Consumer[IO, Fruit], Producer[IO, Fruit])] =
       for {
-        consumer <- Consumer.create[IO, Fruit](client, vTopic, sub("fruits"))
-        producer <- Producer.create[IO, Fruit](client, vTopic)
+        consumer <- Consumer.make[IO, Fruit](client, vTopic, sub("fruits"))
+        producer <- Producer.make[IO, Fruit](client, vTopic)
       } yield consumer -> producer
 
     res.use(_ => IO.pure(expect(true)))
@@ -253,8 +253,8 @@ object NeutronSuite extends IOSuite {
 
     val res: Resource[IO, (Consumer[IO, Inner], Producer[IO, Inner])] =
       for {
-        consumer <- Consumer.create[IO, Inner](client, vTopic, sub("outer-inner"))
-        producer <- Producer.create[IO, Inner](client, vTopic)
+        consumer <- Consumer.make[IO, Inner](client, vTopic, sub("outer-inner"))
+        producer <- Producer.make[IO, Inner](client, vTopic)
       } yield consumer -> producer
 
     res.use(_ => IO.pure(expect(true)))


### PR DESCRIPTION
Use a single `make` constructor in `Consumer`, `Producer`, `Reader` and `Pulsar`.