### PR TITLE
Downgrade to Scala 2.13.5

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,5 @@
 updates.ignore = [
   { groupId = "org.apache.pulsar" },
   { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+  { groupId = "org.scala-lang", artifactId = "scala-library" }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import Settings._
 
-scalaVersion in ThisBuild := "2.13.6"
+ThisBuild / scalaVersion := supportedScala
 
 lazy val `neutron-core` = (project in file("core"))
   .enablePlugins(AutomateHeaderPlugin)
@@ -91,7 +91,7 @@ lazy val docs = (project in file("docs"))
     ghpagesNoJekyll := true,
     version := version.value.takeWhile(_ != '+'),
     paradoxProperties ++= Map(
-          "scala-versions" -> (crossScalaVersions in `neutron-core`).value
+          "scala-versions" -> (`neutron-core` / crossScalaVersions).value
                 .map(CrossVersion.partialVersion)
                 .flatten
                 .map(_._2)
@@ -107,7 +107,7 @@ lazy val docs = (project in file("docs"))
     mdocExtraArguments ++= Seq("--no-link-hygiene"),
     makeSite := makeSite.dependsOn(mdoc.toTask("")).value,
     ParadoxMaterialThemePlugin.paradoxMaterialThemeSettings(Paradox),
-    paradoxMaterialTheme in Paradox := {
+    Paradox / paradoxMaterialTheme := {
       ParadoxMaterialTheme()
         .withColor("red", "orange")
         .withLogoIcon("flash_on")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,15 +5,17 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import Dependencies.CompilerPlugins
 
 object Settings {
+  val supportedScala = "2.13.5"
+
   val commonSettings = Seq(
     scalacOptions ++= compilerFlags(scalaVersion.value),
     scalacOptions -= "-Wunused:params", // so many false-positives :(
-    scalaVersion := "2.13.6",
+    scalaVersion := supportedScala,
     scalafmtOnCompile := true,
     autoAPIMappings := true,
     testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
     libraryDependencies ++= macroParadisePlugin(scalaVersion.value),
-    ThisBuild / crossScalaVersions := Seq("2.13.2"),
+    ThisBuild / crossScalaVersions := Seq(supportedScala),
     ThisBuild / homepage := Some(url("https://github.com/cr-org/neutron")),
     ThisBuild / organization := "com.chatroulette",
     ThisBuild / organizationName := "Chatroulette",
@@ -56,7 +58,7 @@ object Settings {
   )
 
   val noPublish = {
-    skip in publish := true
+    publish / skip := true
   }
 
   def compilerFlags(v: String) =


### PR DESCRIPTION
The upgrade to 2.13.6 was broken because it didn't update the `crossScalaVersions` values: https://github.com/cr-org/neutron/pull/215/files

It doesn't compile with 2.13.6 for now, needs some adjustments.